### PR TITLE
Fix code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/ek_import_blob/main.go
+++ b/ek_import_blob/main.go
@@ -55,7 +55,10 @@ func main() {
 				parts := strings.Split(e, "=")
 				u, err := strconv.ParseUint(parts[0], 10, 64)
 				if err != nil {
-					glog.Fatalf("Error parsing uint64->32: %v\n", err)
+					glog.Fatalf("Error parsing uint64: %v\n", err)
+				}
+				if u > math.MaxUint32 {
+					glog.Fatalf("Parsed value exceeds uint32 range: %v\n", u)
 				}
 
 				hv, err := hex.DecodeString(parts[1])


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/tpm2/security/code-scanning/2](https://github.com/ibiscum/tpm2/security/code-scanning/2)

To fix the problem, we need to add an upper bound check before converting the `uint64` value to a `uint32` value. This will ensure that the value is within the acceptable range for a `uint32`. If the value exceeds the maximum value for a `uint32`, we should handle the error appropriately.

The best way to fix the problem is to:
1. Parse the string into a `uint64` using `strconv.ParseUint`.
2. Check if the parsed value is within the range of a `uint32`.
3. If the value is within the range, convert it to a `uint32`.
4. If the value exceeds the range, handle the error (e.g., log an error message and exit).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
